### PR TITLE
Fix plotting bug in step function.

### DIFF
--- a/optperfprofpy.py
+++ b/optperfprofpy.py
@@ -190,7 +190,7 @@ def draw_simple_pp(taus, solver_vals, solvers):
     
     # Add lines individually to support labels
     for n, solver in enumerate(solvers):
-        ax.step(taus, solver_vals[n, :], label=solver)
+        ax.step(taus, solver_vals[n, :], where='post', label=solver)
         
     plt.legend(loc=4)
     plt.xlim(1, taus.max())


### PR DESCRIPTION
The current step function does not implement the same \rho_s(\tau) function that is used to describe performance profiles. In particular, [matplotlib.pyplot.step](https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.step.html) has the default argument `where='pre'`, which was not used in the original implementation. To more rigorously match the definition of performance profiles, `where='post'` should be used instead. This pull request adds this argument to the call to [matplotlib.pyplot.step](https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.step.html). 